### PR TITLE
Request duration should be histogram

### DIFF
--- a/resources/handler.yaml
+++ b/resources/handler.yaml
@@ -18,7 +18,7 @@ spec:
     - name: requestcount.instance.istio-system
       type: COUNTER
     - name: requestduration.instance.istio-system
-      type: COUNTER
+      type: HISTOGRAM
     - name: requestsize.instance.istio-system
       type: COUNTER
     - name: responsesize.instance.istio-system


### PR DESCRIPTION
The metric request duration doesn't make sense as a counter, as it tracks times. A histogram would be more appropriate as the underlying metric type here is distribution.