### PR TITLE
Match only http/grpc requests for traces

### DIFF
--- a/resources/rules-tracing.yaml
+++ b/resources/rules-tracing.yaml
@@ -9,4 +9,4 @@ spec:
   - handler: signalfx.istio-system
     instances:
     - signalfxtracespan
-  match: "true"
+  match: context.protocol == "http" || context.protocol == "grpc"


### PR DESCRIPTION
We have an istio cluster that uses tcp, and we noticed errors in mixer relating to not being able to look up request.time. In debugging these errors are from mixer trying to apply traces to tcp traffic which have a different request schema. This PR makes it so traces only matche on http and grpc traffic.

```
2019-01-14T21:57:34.160888Z     debug   attributes      Creating bag with attributes: connection.event              : continue                                                       
connection.id                 : cf07ad20-0f2c-4249-bca4-c54249e4fd30-12
connection.mtls               : false
connection.received.bytes     : 6
connection.received.bytes_total: 396682
connection.sent.bytes         : 6
connection.sent.bytes_total   : 301000
context.protocol              : tcp
context.reporter.kind         : outbound
context.reporter.uid          : kubernetes://bifrost-public-857cf67b85-zbj8l.applications
context.time                  : 2019-01-14 21:57:33.159634918 +0000 UTC
destination.ip                : [10 2 95 50]
destination.port              : 4222
destination.service           : nats.applications.svc.cluster.local
destination.service.host      : nats.applications.svc.cluster.local
destination.service.name      : nats
destination.service.namespace : applications
destination.service.uid       : istio://applications/services/nats
destination.uid               : kubernetes://nats-64d6d6f89-nkzqq.applications
origin.ip                     : [10 2 8 62]
source.ip                     : [10 2 8 62]
source.namespace              : applications
source.uid                    : kubernetes://bifrost-public-857cf67b85-zbj8l.applications

2019-01-14T21:57:34.161128Z     error   error creating instance: destination='tracespan.template.istio-system:signalfx.handler.istio-system(signalfx.adapter.istio-system)', error='fieldEncoder: start_time - lookup failed: 'request.time''
2019-01-14T21:57:34.161229Z     error   api     Report failed:3 errors occurred:
```