### PR TITLE
Add config option for global dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For example, the endpoint for sending data in the us1 realm is ingest.us1.signal
 and ingest.eu0.signalfx.com for the eu0 realm. If you try to send data to the incorrect realm,
 your access token will be denied.
 
-> By default, this plugin sends to the us0 realm
+**By default, this plugin sends to the us0 realm**
 
 To determine what realm you are in, check your profile page in the SignalFx web application.
 

--- a/helm/signalfx-istio-adapter/Chart.yaml
+++ b/helm/signalfx-istio-adapter/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: 0.3.0
 description: SignalFx Istio Out-of-process Adapter Helm chart
 name: signalfx-istio-adapter
-version: 0.0.3
+version: 0.0.4

--- a/helm/signalfx-istio-adapter/templates/metric-instances.yaml
+++ b/helm/signalfx-istio-adapter/templates/metric-instances.yaml
@@ -11,6 +11,9 @@ spec:
       {{- with .Values.metricDimensions }}
 {{ toYaml . | trim | indent 6 }}
       {{- end }}
+      {{- with .Values.globalDimensions }}
+{{ toYaml . | trim | indent 6 }}
+      {{- end }}
     monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -24,6 +27,9 @@ spec:
     value: response.duration | "0ms"
     dimensions:
       {{- with .Values.metricDimensions }}
+{{ toYaml . | trim | indent 6 }}
+      {{- end }}
+      {{- with .Values.globalDimensions }}
 {{ toYaml . | trim | indent 6 }}
       {{- end }}
     monitored_resource_type: '"UNSPECIFIED"'
@@ -41,6 +47,9 @@ spec:
       {{- with .Values.metricDimensions }}
 {{ toYaml . | trim | indent 6 }}
       {{- end }}
+      {{- with .Values.globalDimensions }}
+{{ toYaml . | trim | indent 6 }}
+      {{- end }}
     monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -54,6 +63,9 @@ spec:
     value: response.size | 0
     dimensions:
       {{- with .Values.metricDimensions }}
+{{ toYaml . | trim | indent 6 }}
+      {{- end }}
+      {{- with .Values.globalDimensions }}
 {{ toYaml . | trim | indent 6 }}
       {{- end }}
     monitored_resource_type: '"UNSPECIFIED"'
@@ -71,6 +83,9 @@ spec:
       {{- with .Values.metricDimensions }}
 {{ toYaml . | trim | indent 6 }}
       {{- end }}
+      {{- with .Values.globalDimensions }}
+{{ toYaml . | trim | indent 6 }}
+      {{- end }}
     monitored_resource_type: '"UNSPECIFIED"'
 ---
 apiVersion: "config.istio.io/v1alpha2"
@@ -84,6 +99,9 @@ spec:
     value: connection.received.bytes | 0
     dimensions:
       {{- with .Values.metricDimensions }}
+{{ toYaml . | trim | indent 6 }}
+      {{- end }}
+      {{- with .Values.globalDimensions }}
 {{ toYaml . | trim | indent 6 }}
       {{- end }}
     monitored_resource_type: '"UNSPECIFIED"'

--- a/helm/signalfx-istio-adapter/values.yaml
+++ b/helm/signalfx-istio-adapter/values.yaml
@@ -25,6 +25,11 @@ datapointInterval: 10s
 enableMetrics: true
 enableTracing: true
 
+# Map of key/value pairs to report along with metrics, for example:
+# kubernetes_cluster: my-cluster-1
+# foo: bar 
+globalDimensions:
+
 metricConfig:
   - name: requestcount.instance.istio-system
     type: COUNTER


### PR DESCRIPTION
Specific use case for this request was this adapter was being applied across multiple k8s clusters, without an option to add an identifier for the clusters.
Technically, they could append to the `metricDimensions` in the `values.yaml`, but this is a bit more user friendly since those are pre-defined dimensions.