### PR TITLE
Fixed depreceated K8S API in Deployment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ influence the tags that get put on the emitted spans to SignalFx.
 
 To install the chart with Helm, run something like the following command:
 
-`$ helm install --name signalfx-adapter --set fullnameOverride=signalfx-adapter --namespace istio-system --set-string accessToken=MY_ORG_ACCESS_TOKEN ./helm/signalfx-adapter/`
+`$ helm install --name signalfx-adapter --set fullnameOverride=signalfx-adapter --namespace istio-system --set-string accessToken=MY_ORG_ACCESS_TOKEN ./helm/signalfx-istio-adapter/`
 
 or, if using your own values config file:
 

--- a/helm/signalfx-istio-adapter/templates/deployment.yaml
+++ b/helm/signalfx-istio-adapter/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "signalfx-istio.fullname" . }}


### PR DESCRIPTION
Fixed depreceated K8S API in Deployment. Also corrected name of a helm chart folder in command example in README.